### PR TITLE
Replaced ocurrences of GetAllDomains to ListAllDomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ func main(){
 	zeitClient := zeit.NewClient(token)
 	zeitClient.Team("team name") // Team name can be optionally set
 	
-	domains, err := zeitClient.GetAllDomains()
+	domains, err := zeitClient.ListAllDomains()
 	if err != nil {
 		fmt.Println(err.Error())
 	}

--- a/domains.go
+++ b/domains.go
@@ -47,7 +47,7 @@ type Domain struct {
 	Certs               []Certs   `json:"certs,omitempty"`
 }
 
-// GetAllDomains will return a slice of domains registered with the user.
+// ListAllDomains will return a slice of domains registered with the user.
 func (c Client) ListAllDomains() ([]Domain, error) {
 	resp, err := c.makeAndDoRequest(http.MethodGet, "v4/domains", nil)
 	if err != nil {

--- a/domains_test.go
+++ b/domains_test.go
@@ -29,7 +29,7 @@ func makeResponse(response []byte, statusCode int) http.Response {
 	return httpResponse
 }
 
-func TestClient_GetAllDomains(t *testing.T) {
+func TestClient_ListAllDomains(t *testing.T) {
 	a := assert.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
the example in readme does not work, now if it corresponds to the function defined in domains.go
also updated in test file for consistency.